### PR TITLE
Update webkit prefix comment in example

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -244,12 +244,14 @@ For cases where the browser does not support the window controls overlay, a CSS 
 
 .draggable {
   app-region: drag;
-  -webkit-app-region: drag; /* required until app-region is standardized*/
+  /* Pre-fix app-region during standardization process */
+  -webkit-app-region: drag;
 }
 
 .nonDraggable {
   app-region: no-drag;
-  -webkit-app-region: no-drag; /* required until app-region is standardized*/
+  /* Pre-fix app-region during standardization process */
+  -webkit-app-region: no-drag;
 }
 
 body {


### PR DESCRIPTION
Per offline feedback from Jason McConnell, this updates the comment in the example code to be more clear: "Pre-fix app-region during standardization process". 