### PR TITLE
WCO getClientBoundsRect rename for clarity

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -304,8 +304,25 @@ body {
 ```
 ## Considered Alternatives
 
-### `getTitleBarAreaRect` method
-The `windowControlsOverlay` object has a `getBoundingClientRect` method that returns the area of the title bar where is it safe to put content. We consider naming the `windowControlsOverlay.getBoundingClientRect` method to `getTitleBarAreaRect` to remove any ambiguity of the area returned by the method. 
+### Treating the overlay as a notch
+
+Following the pattern of safe-area-inset-*s, we propose new CSS environment variables to define the insets of the unsafe notch area in more detail: 
+
+* Horizontal insets of the notch on the top edge of the screen
+  - unsafe-area-top-inset-left
+  - unsafe-area-top-inset-right
+* Horizontal insets of the notch on the bottom edge of the screen
+  - unsafe-area-bottom-inset-left
+  - unsafe-area-bottom-inset-right
+* Vertical insets of the notch on the left edge of the screen
+  - unsafe-area-left-inset-top
+  - unsafe-area-left-inset-bottom
+* Vertical insets of the notch on the right edge of the screen
+  - unsafe-area-right-inset-top
+  - unsafe-area-right-inset-bottom
+
+This alternative was not feasible in macOS since the overlay is separated in 2 regions in this OS (like having 2 notches). The resulting API was more complex and CSS cumbersome with this approach. See [this issue](https://github.com/w3c/csswg-drafts/issues/4721). 
+
 
 ```javascript
 //prints to console the dimensions of the title bar area

--- a/index.html
+++ b/index.html
@@ -97,6 +97,14 @@
           </pre>
         </aside>
       </section>
+      <aside class="note">
+        <p>
+          The WCO feature is useful in environments that use the paradigm of a
+          window to house applications. Notches, irregular shaped viewports or
+          layout of content around hardware constraints is outside of the scope
+          of the spec.
+        </p>
+      </aside>
     </section>
     <section>
       <h2>
@@ -193,7 +201,7 @@
         [Exposed=Window]
         interface WindowControlsOverlay : EventTarget {
           readonly attribute boolean visible;
-          DOMRect getBoundingClientRect();
+          DOMRect getTitlebarAreaRect();
           attribute EventHandler ongeometrychange;
         };
 
@@ -220,15 +228,15 @@
       </section>
       <section>
         <h3>
-          The <dfn>getBoundingClientRect</dfn> method
+          The <dfn>getTitlebarAreaRect</dfn> method
         </h3>
         <p>
-          The `getBoundingClientRect()` method returns a DOMRect that
-          represents the available area for displaying web content. This
-          available title bar region does not include the area under the
-          [=window controls=] [=overlay=].
+          The `getTitlebarAreaRect()` method returns a DOMRect that represents
+          the available area for displaying web content. This available title
+          bar region does not include the area under the [=window controls=]
+          [=overlay=].
         </p><img src="spec-wco-gbr.png" alt=
-        "depiction of the area returned by the getBoundingClientRect method">
+        "depiction of the area returned by the getTitlebarAreaRect method">
         <aside class="note">
           <p>
             The client viewport does not make any special considerations when
@@ -236,7 +244,7 @@
             displayed in the same way that it would be displayed inside the
             browser window. In order to avoid content being hidden by the area
             where the [=window controls=] are [=overlaid=], developers need to
-            use the `getBoundingClientRect` method or the [=title bar area env
+            use the `getTitlebarAreaRect` method or the [=title bar area env
             variables=].
           </p>
         </aside>

--- a/index.html
+++ b/index.html
@@ -104,6 +104,29 @@
           layout of content around hardware constraints is outside of the scope
           of the spec.
         </p>
+        <p>
+          The window paradigm for desktop-like environments is UX that has
+          proven effective at managing information architecture over decades.
+          It is a paradigm that continues to evolve, and part of this evolution
+          is allowing modern apps to take control of the area of the window
+          that was before reserved for the title bar. WCO enables this in the
+          same way that apps created with native technologies can take
+          advantage of today.
+        </p>
+        <p>
+          <strong>Notches and other hardware elements do not interfere with the
+          title bar region of any app window on any platform</strong>. They can
+          intersect parts of the OS such as the status or menu area, and this
+          is handled entirely by the host OS. The WCO feature does not deal
+          with any area that can be intersected by a notch.
+        </p>
+        <p>
+          Notches do not leave considerable space to work with, can be in
+          arbitrary positions, and not necessarily be rectangular.
+          Additionally, most GUI guidelines from vendors that implement notches
+          to maximize screen-body ratio on their devices recommend not to
+          position content around the notch.
+        </p>
       </aside>
     </section>
     <section>


### PR DESCRIPTION
-Renames getClientBoundsRect
-adds considered alternative of treating overlay as a notch in explainer
-adds note clarifying approach of WCO + notches.