### PR TITLE
Renamed display-override to display_override

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,7 +274,7 @@
         <aside class="note">
           <p>
             If a user agent does not support WCO, the developer can use
-            reasonable fallbacks for both the `display-override` using
+            reasonable fallbacks for both the `display_override` using
             `display` and the CSS variables and JS object accordingly.
           </p>
         </aside>
@@ -295,8 +295,8 @@
       </h2>
       <p>
         To enable the WCO feature, a new value will be added to the
-        `display-override` member of the manifest file. When the
-        `window-controls-overlay` value is specified in the `display-override`
+        `display_override` member of the manifest file. When the
+        `window-controls-overlay` value is specified in the `display_override`
         the user agent SHOULD extend the client area to the title bar.
       </p>
       <aside class="issue">


### PR DESCRIPTION
The name of the member to use in the web app manifest file is `display_override`. However the spec mentions `display-override` instead (dash instead of underscore).