### PR TITLE
Use event type instead of eventhandler attribute name

### DIFF
--- a/index.html
+++ b/index.html
@@ -425,7 +425,7 @@
           as a result of the user resizing the browser window, or changing the
           page zoom factor, or other UI appearing or disappearing on the
           [=overlay=]), since the last time these steps were run, [=fire an
-          event=] named `ongeometrychange` at the {{Window/window}} object and
+          event=] named `geometrychange` at the {{Window/window}} object and
           [=update the overlay area information=].
           </li>
         </ol>


### PR DESCRIPTION
in algorithm to fire an event, per the DOM spec