### PR TITLE
Move draggable regions to the manifest incubations spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,8 +317,8 @@
         <dd>
           The web application opens with native OS window controls visible but
           with the web contents extended to the rest of the title bar area. The
-          app will also be able to specify draggable regions in the web contents
-          to create a customized title bar.
+          app will also be able to specify [=draggable region=]s in the web
+          contents to create a customized title bar.
         </dd>
      </dl>
       <p>
@@ -403,29 +403,6 @@
           bounds.
         </p>
       </section>
-    </section>
-    <section>
-      <h2>
-        Defining draggable sections
-      </h2>
-      <p>
-        To define which regions or elements in the title bar are draggable,
-        this specification defines the CSS <code><dfn>`app-region`</dfn></code>
-        property.
-      </p>
-      <p>
-        To enable dragging an element, [=app-region=] shall be set to `drag`.
-      </p>
-      <p>
-        To disable dragging an element, [=app-region=] shall be set to `no-drag`.
-      </p>
-      <aside class="issue">
-        <p>
-          TO DO: This is draft text for features that might belong in other
-          specifications. This document might not be the final venue for some
-          of the work specified in this draft. (CSS)
-        </p>
-      </aside>
     </section>
     <section>
       <h2>


### PR DESCRIPTION
This is because it is also used by borderless mode and potentially with also other display_override modes in the future too.

The corresponding [PR](https://github.com/WICG/manifest-incubations/pull/74).